### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v1
     
     - name: Build and push the Docker image
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: docker.pkg.github.com/kondoumh/devel-containers/gitpod
         username: kondoumh


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore